### PR TITLE
Display logs from lambda function

### DIFF
--- a/packages/appsync-emulator-serverless/lambda/util.js
+++ b/packages/appsync-emulator-serverless/lambda/util.js
@@ -69,10 +69,13 @@ function installStdIOHandlers(runtime, proc, payload) {
           let lines = allResults.split('\n');
           let idx = 0;
           let jsonResults = '';
-          for(; idx < lines.length; idx++) {
+          for(idx = lines.length - 1; idx >= 0; idx--) {
             // Trying to guess when it's the start of our function output, and not a random logging statement
+            // Searching backwards so we don't erroneously trigger if someone logs a dictionary (python) in the function
             if (lines[idx].startsWith('{')) break;
           }
+          let lambdaDebugLog = lines.slice(0, idx).join('\n')
+          log.info('Lambda function logs:\n' + lambdaDebugLog)
           jsonResults = lines.slice(idx).join('');
           sendOutput(JSON.parse(jsonResults));
         }


### PR DESCRIPTION
Add a log line that dumps the logging output from the lambda function. Update the function output logic to search for the start of the output ("{") starting from the end and working backwards to stop it from falsely triggering off of a dictionary print (Python). 