### PR TITLE
Allow logging prints to occur before and after the JSON result, also when a traceback is received log it to the console

### DIFF
--- a/packages/appsync-emulator-serverless/lambda/util.js
+++ b/packages/appsync-emulator-serverless/lambda/util.js
@@ -1,4 +1,4 @@
-const log = require('logdown')('appsync-emulator:lambdaRunner');
+const log = require('logdown')('appsync-emulator:lambdaRunner', { markdown: false });
 
 const parseErrorStack = error =>
   error.stack


### PR DESCRIPTION
Allow logging prints to occur before and after the JSON result, also when a traceback is received log it to the console.

Also highlight in green the text that was parsed out as the result, example:

<img width="1130" alt="image" src="https://user-images.githubusercontent.com/8854186/63304491-0f5bc200-c298-11e9-9113-40e534e8cc36.png">
